### PR TITLE
Requirements messages

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -2624,6 +2624,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: It's Spreading!
+  requirementsNotMetMessage: 
   isInteractable: 1
   dataDrive: {fileID: 11400000, guid: a9cf99e7cba4c7f43a556ad8cba5a369, type: 2}
 --- !u!1 &50563559
@@ -3080,6 +3081,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1442733626}
@@ -3153,6 +3155,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -4419,6 +4422,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 929983935}
@@ -4492,6 +4496,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -9287,6 +9292,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: 
+  requirementsNotMetMessage: 
   isInteractable: 1
   key: 1
   task: {fileID: 11400000, guid: 8e0b4c009488d7443930b234c583aa9d, type: 2}
@@ -10134,6 +10140,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Take Weapons Keycard 2
+  requirementsNotMetMessage: 
   isInteractable: 1
   key: 1
   sfx: {fileID: 8300000, guid: 29c571417dd50654899bc8b6ea1e840b, type: 3}
@@ -11047,6 +11054,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -11959,6 +11967,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -12030,6 +12039,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -17677,6 +17687,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: 
+  requirementsNotMetMessage: 
   isInteractable: 1
   key: 0
   task: {fileID: 11400000, guid: 8e0b4c009488d7443930b234c583aa9d, type: 2}
@@ -18726,6 +18737,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1898071307}
@@ -20609,6 +20621,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 28971736}
@@ -22100,6 +22113,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Read Post-It
+  requirementsNotMetMessage: 
   isInteractable: 1
   hasText: 0
   textTranscript: '...and for our FUTURE
@@ -22941,6 +22955,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 615800600}
@@ -23741,6 +23756,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Take "The World For Two" PD
+  requirementsNotMetMessage: 
   isInteractable: 1
   dataDrive: {fileID: 11400000, guid: 6df48d5f3dfdb4f4897b89f6c5153b60, type: 2}
 --- !u!1 &287407148
@@ -23897,6 +23913,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 1
   driveStored: {fileID: 11400000, guid: f879787bdbebe4f10aaf528fd3fa4606, type: 2}
   serverAnim: {fileID: 275292305}
@@ -25109,6 +25126,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -25554,6 +25572,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1867476824}
@@ -28222,6 +28241,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 11400000, guid: c1022cad557514cc292be2e3d36ed78c, type: 2}
   serverAnim: {fileID: 1416046666}
@@ -29573,7 +29593,7 @@ MonoBehaviour:
   m_PreserveMeshAssetOnDestroy: 0
   assetGuid: 
   m_Mesh: {fileID: 1624204795}
-  m_VersionIndex: 188
+  m_VersionIndex: 194
   m_IsSelectable: 1
   m_SelectedFaces: 
   m_SelectedEdges: []
@@ -29658,6 +29678,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Disengage Safety
+  requirementsNotMetMessage: 
   isInteractable: 1
   task: {fileID: 11400000, guid: f4905a7e6614fa8489322f04643b5573, type: 2}
   safetyOffLine: {fileID: 8300000, guid: 38619e0e0ab2a004281a367e7a6c03a8, type: 3}
@@ -31021,6 +31042,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1519723299}
@@ -31372,6 +31394,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1725833875}
@@ -31838,6 +31861,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -32492,6 +32516,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1369136976}
@@ -35198,6 +35223,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -35599,6 +35625,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 581427659}
@@ -37786,6 +37813,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 1
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -38401,6 +38429,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 11400000, guid: e92b1d9f37c8c974d9842de50e309324, type: 2}
   serverAnim: {fileID: 716678271}
@@ -38751,6 +38780,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1238319543}
@@ -39980,6 +40010,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run sword_warmpup.exe
+  requirementsNotMetMessage: 
   isInteractable: 1
   exe: {fileID: 620950283}
   usableInPhaseOne: 0
@@ -42741,6 +42772,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Read Post-It
+  requirementsNotMetMessage: 
   isInteractable: 1
   hasText: 1
   textTranscript: No time to say goodbye. Be well, I'll miss you\n\t\t-C.M.
@@ -43318,6 +43350,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 599363562}
@@ -43532,6 +43565,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Be The Weapon
+  requirementsNotMetMessage: 
   isInteractable: 1
   task: {fileID: 11400000, guid: a39d6bd0373568842b5b1d216523763d, type: 2}
   gameOverUI: {fileID: 1938501010}
@@ -43595,6 +43629,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1903789152}
@@ -43954,6 +43989,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 354519362}
@@ -44401,6 +44437,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Sit
+  requirementsNotMetMessage: 
   isInteractable: 1
   sitPoint: {fileID: 1695462219}
   sfx: {fileID: 8300000, guid: 888a835720eca014aa6c225557368e38, type: 3}
@@ -44721,6 +44758,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -45097,6 +45135,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Read Post-It
+  requirementsNotMetMessage: 
   isInteractable: 1
   hasText: 1
   textTranscript: I think I can see my house\n\t\t-C.M.
@@ -45147,6 +45186,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 636696680}
@@ -49091,6 +49131,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -51468,6 +51509,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -52189,6 +52231,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Sit
+  requirementsNotMetMessage: 
   isInteractable: 1
   sitPoint: {fileID: 1555767593}
   sfx: {fileID: 8300000, guid: 888a835720eca014aa6c225557368e38, type: 3}
@@ -53215,6 +53258,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -53429,6 +53473,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -53738,6 +53783,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -54523,6 +54569,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -54924,6 +54971,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1720680413}
@@ -56526,6 +56574,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -56597,6 +56646,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -58952,6 +59002,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Take Weapons Keycard 1
+  requirementsNotMetMessage: 
   isInteractable: 1
   key: 0
   sfx: {fileID: 8300000, guid: 29c571417dd50654899bc8b6ea1e840b, type: 3}
@@ -59122,6 +59173,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1701134489}
@@ -60149,6 +60201,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -61226,6 +61279,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1293344836}
@@ -61299,6 +61353,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -61911,6 +61966,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1133078443}
@@ -62603,6 +62659,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Read Post-It
+  requirementsNotMetMessage: 
   isInteractable: 1
   hasText: 1
   textTranscript: This one was green briefly last week, I swear. I'll find out what's
@@ -62893,6 +62950,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1367304049}
@@ -64750,6 +64808,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1480246652}
@@ -65811,6 +65870,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -68710,6 +68770,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 1
   driveStored: {fileID: 11400000, guid: e92b1d9f37c8c974d9842de50e309324, type: 2}
   serverAnim: {fileID: 1665588843}
@@ -71128,6 +71189,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1918308967}
@@ -71201,6 +71263,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -71532,6 +71595,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Calibrate Weapon Arm 2
+  requirementsNotMetMessage: 
   isInteractable: 1
   isFlipped: 0
   otherLever: {fileID: 1841930897}
@@ -72180,6 +72244,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 979858362}
@@ -75193,6 +75258,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 540215682}
@@ -75476,6 +75542,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -76500,6 +76567,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -77214,6 +77282,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -78654,6 +78723,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: 
+  requirementsNotMetMessage: 
   isInteractable: 1
   radio: {fileID: 1585626243}
   onDial: {fileID: 2076453166}
@@ -81068,7 +81138,7 @@ MonoBehaviour:
   m_PreserveMeshAssetOnDestroy: 0
   assetGuid: 
   m_Mesh: {fileID: 1881508344}
-  m_VersionIndex: 837
+  m_VersionIndex: 843
   m_IsSelectable: 1
   m_SelectedFaces: 
   m_SelectedEdges: []
@@ -85233,6 +85303,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -88049,7 +88120,7 @@ MonoBehaviour:
   m_PreserveMeshAssetOnDestroy: 0
   assetGuid: 
   m_Mesh: {fileID: 1792362207}
-  m_VersionIndex: 60
+  m_VersionIndex: 66
   m_IsSelectable: 1
   m_SelectedFaces: 
   m_SelectedEdges: []
@@ -88804,6 +88875,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 773626267}
@@ -96278,6 +96350,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -96721,6 +96794,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1871138233}
@@ -98117,6 +98191,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Pickup TaskPad
+  requirementsNotMetMessage: 
   isInteractable: 1
   tidy: {fileID: 0}
   sfx: {fileID: 8300000, guid: 29c571417dd50654899bc8b6ea1e840b, type: 3}
@@ -98301,6 +98376,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -98575,6 +98651,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 848721467}
@@ -99651,6 +99728,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -101929,6 +102007,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Sit
+  requirementsNotMetMessage: 
   isInteractable: 1
   sitPoint: {fileID: 294858632}
   sfx: {fileID: 8300000, guid: 888a835720eca014aa6c225557368e38, type: 3}
@@ -103590,6 +103669,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -104340,6 +104420,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Sit
+  requirementsNotMetMessage: 
   isInteractable: 1
   sitPoint: {fileID: 764337555}
   sfx: {fileID: 8300000, guid: 888a835720eca014aa6c225557368e38, type: 3}
@@ -105273,6 +105354,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -108109,6 +108191,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -108180,6 +108263,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -108500,6 +108584,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1278238825}
@@ -110222,6 +110307,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1842988991}
@@ -110375,6 +110461,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Calibrate Weapon Arm 1
+  requirementsNotMetMessage: 
   isInteractable: 1
   isFlipped: 0
   otherLever: {fileID: 1183576039}
@@ -110633,6 +110720,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 145558692}
@@ -110871,6 +110959,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -111287,6 +111376,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 930278784}
@@ -111527,6 +111617,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 11400000, guid: 5803ff7758e2dd6488fde95a09d9837b, type: 2}
   serverAnim: {fileID: 510252508}
@@ -111767,6 +111858,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -112518,6 +112610,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1072526962}
@@ -112879,6 +112972,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -115787,6 +115881,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1248121335}
@@ -116929,6 +117024,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Notice of Dismissal
+  requirementsNotMetMessage: 
   isInteractable: 1
   hasText: 0
   textTranscript: 
@@ -117809,6 +117905,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Play/Pause PD Audio
+  requirementsNotMetMessage: 
   isInteractable: 1
   dataReader: {fileID: 419518823815663100}
   audioSource: {fileID: 2988883396883619984}
@@ -118338,6 +118435,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 503191807}
@@ -118486,6 +118584,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -118698,6 +118797,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -119004,6 +119104,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Run .exe
+  requirementsNotMetMessage: 
   isInteractable: 0
   exe: {fileID: 0}
   usableInPhaseOne: 0
@@ -119895,6 +119996,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: CONTROLLED ON RUNTIME
+  requirementsNotMetMessage: 
   isInteractable: 0
   driveStored: {fileID: 0}
   serverAnim: {fileID: 1418005925}
@@ -135570,7 +135672,7 @@ PrefabInstance:
       objectReference: {fileID: 294169553}
     - target: {fileID: 985167535185015633, guid: ef772a0a98d964fde9e19d48e82ec666, type: 3}
       propertyPath: m_VersionIndex
-      value: 2170
+      value: 2176
       objectReference: {fileID: 0}
     - target: {fileID: 1068064095377501721, guid: ef772a0a98d964fde9e19d48e82ec666, type: 3}
       propertyPath: m_IsActive
@@ -135854,7 +135956,7 @@ PrefabInstance:
       objectReference: {fileID: 39838369}
     - target: {fileID: 4295154614022084366, guid: ef772a0a98d964fde9e19d48e82ec666, type: 3}
       propertyPath: m_VersionIndex
-      value: 2170
+      value: 2176
       objectReference: {fileID: 0}
     - target: {fileID: 4489193700482519121, guid: ef772a0a98d964fde9e19d48e82ec666, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -174558,6 +174660,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   promptMessage: Take Wellness Vol. 2 PD
+  requirementsNotMetMessage: 
   isInteractable: 1
   dataDrive: {fileID: 11400000, guid: 5745374bc413f544cbe4789fb6f9a6c4, type: 2}
 --- !u!4 &9219275404760603406

--- a/Assets/Scripts/Interactables/Interactable.cs
+++ b/Assets/Scripts/Interactables/Interactable.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 public abstract class Interactable :MonoBehaviour
 {
     [SerializeField] protected string promptMessage;
+    [SerializeField] protected string requirementsNotMetMessage;
     [SerializeField] protected bool isInteractable = true;
 
     public void BaseInteract(Transform player)
@@ -13,6 +14,11 @@ public abstract class Interactable :MonoBehaviour
     public virtual string GetPrompt()
     {
         return promptMessage;
+    }
+
+    public virtual string GetRequirementMessage()
+    {
+        return requirementsNotMetMessage;
     }
 
     public virtual bool CanInteract()

--- a/Assets/Scripts/Interactables/KeycardInput.cs
+++ b/Assets/Scripts/Interactables/KeycardInput.cs
@@ -1,4 +1,3 @@
-using Unity.VisualScripting;
 using UnityEngine;
 
 public class KeycardInput : Interactable
@@ -19,17 +18,37 @@ public class KeycardInput : Interactable
 
     private bool keyInserted = false;
 
+    private const string KEYCARD1INSERT = "Insert Keycard 1";
+    private const string KEYCARD2INSERT = "Insert Keycard 2";
+    private const string KEYCARD1NEEDED = "Requires Keycard 1";
+    private const string KEYCARD2NEEDED = "Requires Keycard 2";
+
     public override bool CanInteract()
     {
-        return TaskManager.Instance.tasks.Contains(task) && !keyInserted;
+        return TaskManager.Instance.tasks.Contains(task) && !keyInserted
+            && ((key == KeyCardRequired.One && PlayerInventory.Instance.hasKeycard1)
+               || (key == KeyCardRequired.Two && PlayerInventory.Instance.hasKeycard2));
     }
 
     public override string GetPrompt()
     {
         if(key == KeyCardRequired.One)
-            return !PlayerInventory.Instance.hasKeycard1 ? "REQUIRES KEYCARD 1" : "INSERT KEYCARD 1";
-        else if(key == KeyCardRequired.Two)
-            return !PlayerInventory.Instance.hasKeycard2 ? "REQUIRES KEYCARD 2" : "INSERT KEYCARD 2";
+            return KEYCARD1INSERT;
+        else if (key == KeyCardRequired.Two)
+            return KEYCARD2INSERT;
+
+        return string.Empty;
+    }
+
+    public override string GetRequirementMessage()
+    {
+        if (TaskManager.Instance.tasks.Contains(task) && !keyInserted)
+        {
+            if (key == KeyCardRequired.One)
+                return KEYCARD1NEEDED;
+            else if (key == KeyCardRequired.Two)
+                return KEYCARD2NEEDED;
+        }
 
         return string.Empty;
     }

--- a/Assets/Scripts/Player/PlayerInteract.cs
+++ b/Assets/Scripts/Player/PlayerInteract.cs
@@ -34,6 +34,7 @@ public class PlayerInteract : MonoBehaviour
 
                 if (interactable.CanInteract())
                 {
+                    promptText.color = UIColors.white;
                     promptText.text = interactable.GetPrompt();
                     buttonPromptObject.SetActive(true);
 
@@ -41,6 +42,10 @@ public class PlayerInteract : MonoBehaviour
                     {
                         interactable.BaseInteract(transform);
                     }
+                } else
+                {
+                    promptText.color = UIColors.terminalRed;
+                    promptText.text = interactable.GetRequirementMessage();
                 }
             }
         }

--- a/Assets/Scripts/UI/UIColors.cs
+++ b/Assets/Scripts/UI/UIColors.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+public static class UIColors
+{
+    public static Color white = new Color(1, 1, 1);
+    public static Color terminalRed = new Color(0.69f, 0.3f, 0.22f);
+
+}

--- a/Assets/Scripts/UI/UIColors.cs.meta
+++ b/Assets/Scripts/UI/UIColors.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ca1f0a0c2b1cea14bb54e9d4598fd42b


### PR DESCRIPTION
Adds red messages that can be shown when an interactable currently is not interactable.

The default behaviour is a new field in the editor for all interactables
![image](https://github.com/user-attachments/assets/545627c7-6036-480a-9078-9ced91f1e68d)
This will be shown whenever you can't interact with that object.

There is however an overridable function that will allow you to add additional logic which OVERWRITES the editor field (same as prompt messages)

Currently, this is only implemented for the keycards on the weapon, and the reject message is set to only show once that task becomes active
![image](https://github.com/user-attachments/assets/57a0a41a-6dc3-4fbf-971d-609b47d111c5)
