### PR TITLE
[BUG] Disappearing Util Doors

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -138071,7 +138071,9 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 356201676}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 7985306160480701205, guid: 71171ec38ae62b74e826434cdad83a89, type: 3}
+    - {fileID: 389544167560834218, guid: 71171ec38ae62b74e826434cdad83a89, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []


### PR DESCRIPTION
In #43 the doors were prefabbed but this included copying over the 'task state change' component which these aren't supposed to have