### PR TITLE
Better Input Sensitivity

### DIFF
--- a/Assets/Prefabs/UI.prefab
+++ b/Assets/Prefabs/UI.prefab
@@ -6557,10 +6557,10 @@ MonoBehaviour:
   m_FillRect: {fileID: 106607739921592831}
   m_HandleRect: {fileID: 927767701255763754}
   m_Direction: 0
-  m_MinValue: 0
+  m_MinValue: 1
   m_MaxValue: 10
   m_WholeNumbers: 1
-  m_Value: 7
+  m_Value: 5
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -10400,7 +10400,7 @@ MonoBehaviour:
   slider: {fileID: 1438953024267860781}
   valueDisplay: {fileID: 4442403240219352083}
   actualValueOffset: 0
-  actualValuePerIncrement: 0.25
+  actualValuePerIncrement: 0.2
 --- !u!1 &9142494296668536052
 GameObject:
   m_ObjectHideFlags: 0
@@ -10747,10 +10747,10 @@ MonoBehaviour:
   m_FillRect: {fileID: 6973169632804327290}
   m_HandleRect: {fileID: 4368994505988537987}
   m_Direction: 0
-  m_MinValue: 0
+  m_MinValue: 1
   m_MaxValue: 10
   m_WholeNumbers: 1
-  m_Value: 7
+  m_Value: 5
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -312,10 +312,6 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4890133332672803936, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
-      propertyPath: actualValuePerIncrement
-      value: 2
-      objectReference: {fileID: 0}
     - target: {fileID: 5193869270774491235, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
       propertyPath: m_Pivot.x
       value: 0
@@ -403,10 +399,6 @@ PrefabInstance:
     - target: {fileID: 5263967492494766965, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5368031008782253265, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
-      propertyPath: actualValuePerIncrement
-      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5457568311508287602, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -312,6 +312,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4890133332672803936, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
+      propertyPath: actualValuePerIncrement
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 5193869270774491235, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
       propertyPath: m_Pivot.x
       value: 0
@@ -400,6 +404,10 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5368031008782253265, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
+      propertyPath: actualValuePerIncrement
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 5457568311508287602, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -438,6 +446,30 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6973169632804327290, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8172288394354015957, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8172288394354015957, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8172288394354015957, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8172288394354015957, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8172288394354015957, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8172288394354015957, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -47973,6 +48005,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 48d7b9d33823d004fb7275e7212a7544, type: 3}
+--- !u!114 &773312150 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5368031008782253265, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
+  m_PrefabInstance: {fileID: 1977882}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ff7f5eaa35027554eafa6edfa4e72e0f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &773626265
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -118707,6 +118750,17 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 1.0572201, z: 0.24064867}
   m_Center: {x: 0, y: 0.028610175, z: 0.0074061714}
+--- !u!114 &2044493599 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4890133332672803936, guid: 3f8903c825779394080c3cc8b3d7f25d, type: 3}
+  m_PrefabInstance: {fileID: 1977882}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ff7f5eaa35027554eafa6edfa4e72e0f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2047173439 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7120528954219165048, guid: ef772a0a98d964fde9e19d48e82ec666, type: 3}
@@ -141511,6 +141565,14 @@ PrefabInstance:
       propertyPath: mouseSensitivy
       value: 
       objectReference: {fileID: 2100406762}
+    - target: {fileID: -7264112560730566213, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
+      propertyPath: controllerXSensitivity
+      value: 
+      objectReference: {fileID: 2044493599}
+    - target: {fileID: -7264112560730566213, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
+      propertyPath: controllerYSensitivity
+      value: 
+      objectReference: {fileID: 773312150}
     - target: {fileID: 123873586549741245, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
       propertyPath: m_text
       value: '<b>Rapier 06 </b>
@@ -141582,7 +141644,7 @@ PrefabInstance:
       objectReference: {fileID: 1314308194}
     - target: {fileID: 525726324227998627, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
       propertyPath: m_VersionIndex
-      value: 1285
+      value: 1288
       objectReference: {fileID: 0}
     - target: {fileID: 916898657491349458, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
       propertyPath: m_Mesh
@@ -141590,7 +141652,7 @@ PrefabInstance:
       objectReference: {fileID: 1940363091}
     - target: {fileID: 916898657491349458, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
       propertyPath: m_VersionIndex
-      value: 934
+      value: 937
       objectReference: {fileID: 0}
     - target: {fileID: 1111038600897101696, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
@@ -141602,7 +141664,7 @@ PrefabInstance:
       objectReference: {fileID: 1737618165}
     - target: {fileID: 1122059581148116338, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
       propertyPath: m_VersionIndex
-      value: 934
+      value: 937
       objectReference: {fileID: 0}
     - target: {fileID: 1342519930052903901, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
       propertyPath: m_Mesh

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -141573,6 +141573,10 @@ PrefabInstance:
       propertyPath: controllerYSensitivity
       value: 
       objectReference: {fileID: 773312150}
+    - target: {fileID: -7264112560730566213, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
+      propertyPath: macSensitivtyMultiplier
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 123873586549741245, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
       propertyPath: m_text
       value: '<b>Rapier 06 </b>
@@ -141644,7 +141648,7 @@ PrefabInstance:
       objectReference: {fileID: 1314308194}
     - target: {fileID: 525726324227998627, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
       propertyPath: m_VersionIndex
-      value: 1288
+      value: 1291
       objectReference: {fileID: 0}
     - target: {fileID: 916898657491349458, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
       propertyPath: m_Mesh
@@ -141652,7 +141656,7 @@ PrefabInstance:
       objectReference: {fileID: 1940363091}
     - target: {fileID: 916898657491349458, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
       propertyPath: m_VersionIndex
-      value: 937
+      value: 940
       objectReference: {fileID: 0}
     - target: {fileID: 1111038600897101696, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
@@ -141664,7 +141668,7 @@ PrefabInstance:
       objectReference: {fileID: 1737618165}
     - target: {fileID: 1122059581148116338, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
       propertyPath: m_VersionIndex
-      value: 937
+      value: 940
       objectReference: {fileID: 0}
     - target: {fileID: 1342519930052903901, guid: a0aeb80084dd8ec4cad85c69bf45e06b, type: 3}
       propertyPath: m_Mesh

--- a/Assets/Scripts/Player/InputManager.cs
+++ b/Assets/Scripts/Player/InputManager.cs
@@ -114,11 +114,6 @@ public class InputManager : MonoBehaviour
     private void Update()
     {
         motor.ProcessMove(playerActions.Move.ReadValue<Vector2>());
-
-    }
-
-    private void LateUpdate()
-    {
         look.ProcessLook(playerActions.Look.ReadValue<Vector2>());
     }
 

--- a/Assets/Scripts/Player/PlayerLook.cs
+++ b/Assets/Scripts/Player/PlayerLook.cs
@@ -33,15 +33,22 @@ public class PlayerLook : MonoBehaviour
         if (lookLocked) return;
 
         bool isMouse = InputManager.Instance.lastInputType == InputManager.LastInputType.KeyboardMouse;
+        float frameMultiplier = isMouse ? 1f : Mathf.Clamp(Time.deltaTime * 144f, 0.5f, 1.5f);
         float xSensitivity = isMouse ? mouseSensitivy.GetModifiedValue() : controllerXSensitivity.GetModifiedValue();
         float ySensitivity = isMouse ? mouseSensitivy.GetModifiedValue() : controllerYSensitivity.GetModifiedValue();
 
-        float mouseX = input.x * xSensitivity;
-        float mouseY = input.y * ySensitivity;
+        if (!isMouse)
+        {
+            input.x = Mathf.Sign(input.x) * Mathf.Pow(Mathf.Abs(input.x), 1.5f);
+            input.y = Mathf.Sign(input.y) * Mathf.Pow(Mathf.Abs(input.y), 1.5f);
+        }
 
-        xRotation -= mouseY;
+        float inputX = input.x * xSensitivity * frameMultiplier;
+        float inputY = input.y * ySensitivity * frameMultiplier;
+
+        xRotation -= inputY;
         xRotation = Mathf.Clamp(xRotation, -80f, 80f); // up down
-        transform.Rotate(Vector3.up * mouseX); // left right
+        transform.Rotate(Vector3.up * inputX); // left right
 
 
         float camZ = 0f;

--- a/Assets/Scripts/Player/PlayerLook.cs
+++ b/Assets/Scripts/Player/PlayerLook.cs
@@ -8,6 +8,8 @@ public class PlayerLook : MonoBehaviour
     private float xRotation = 0f;
 
     [SerializeField] private MenuSlider mouseSensitivy;
+    [SerializeField] private MenuSlider controllerXSensitivity;
+    [SerializeField] private MenuSlider controllerYSensitivity;
 
     private float currentShakeTimer = 0f;
     private float timeToShake = 0f;
@@ -30,11 +32,17 @@ public class PlayerLook : MonoBehaviour
     {
         if (lookLocked) return;
 
-        float mouseX = input.x;
-        float mouseY = input.y;
+        bool isMouse = InputManager.Instance.lastInputType == InputManager.LastInputType.KeyboardMouse;
+        float xSensitivity = isMouse ? mouseSensitivy.GetModifiedValue() : controllerXSensitivity.GetModifiedValue();
+        float ySensitivity = isMouse ? mouseSensitivy.GetModifiedValue() : controllerYSensitivity.GetModifiedValue();
 
-        xRotation -= mouseY * mouseSensitivy.GetModifiedValue();
-        xRotation = Mathf.Clamp(xRotation, -80f, 80f);
+        float mouseX = input.x * xSensitivity;
+        float mouseY = input.y * ySensitivity;
+
+        xRotation -= mouseY;
+        xRotation = Mathf.Clamp(xRotation, -80f, 80f); // up down
+        transform.Rotate(Vector3.up * mouseX); // left right
+
 
         float camZ = 0f;
         if(isShaking)
@@ -63,7 +71,6 @@ public class PlayerLook : MonoBehaviour
 
         cam.transform.localRotation = Quaternion.Euler(xRotation, 0f, camZ);
 
-        transform.Rotate(Vector3.up * mouseX * mouseSensitivy.GetModifiedValue());
     }
 
     public void ToggleLookLock(bool resetCamera = true)

--- a/Assets/Scripts/Player/PlayerLook.cs
+++ b/Assets/Scripts/Player/PlayerLook.cs
@@ -5,22 +5,27 @@ public class PlayerLook : MonoBehaviour
     public static PlayerLook Instance {  get; private set; }
 
     public Camera cam;
-    private float xRotation = 0f;
 
+    [Header("Sensitivity Settings")]
     [SerializeField] private MenuSlider mouseSensitivy;
     [SerializeField] private MenuSlider controllerXSensitivity;
     [SerializeField] private MenuSlider controllerYSensitivity;
 
+    [SerializeField] private float macSensitivtyMultiplier;
+    private const string MAC = "Mac";
+
+    public bool lookLocked = false;
+
+    private float xRotation = 0f;
+
+    // Shake Variables
     private float currentShakeTimer = 0f;
     private float timeToShake = 0f;
     private bool isShaking = false;
     private bool ascendingIntensity = false;
     private float cameraShakeIntensity = 5f;
-
     private bool isDescendingShake = false;
     private float timeToDescend = 0f;
-
-    public bool lookLocked = false;
 
     private void Awake()
     {
@@ -41,6 +46,10 @@ public class PlayerLook : MonoBehaviour
         {
             input.x = Mathf.Sign(input.x) * Mathf.Pow(Mathf.Abs(input.x), 1.5f);
             input.y = Mathf.Sign(input.y) * Mathf.Pow(Mathf.Abs(input.y), 1.5f);
+        } else if (SystemInfo.operatingSystem.Contains(MAC))
+        {
+            input.x *= macSensitivtyMultiplier;
+            input.y *= macSensitivtyMultiplier;
         }
 
         float inputX = input.x * xSensitivity * frameMultiplier;


### PR DESCRIPTION
This tries to make sensitivity as consistent as possible. On this PR I'll provide some context as to why it's done how it is for each input:

### Mouse
Unity's new input action system (that we're using) automatically scales the raw values for frame rate. Whilst it's not perfect at extremes, manually overwriting this just seemed to make things worse so **mouse just uses raw input values multiplied by player sensitivity**.

Sensitivity is a scale of 1-10 which behind the scenes are multiples of 0.01 (small value as frame scaling makes input values bigger)

### Gamepad
Gamepad DOES NOT get any default scaling, and unlike mice they always report a value of -1 -> 1. As a result some smoothing and some different scaling applies
- Add frame multiplier. This for now scales it by between 50% and 150% based on how far off a target of 144fps we are (this would need to change if we ever include frame capping in settings)
- Smoothing - puts input to the power of 1.5 which makes smaller inputs more precise and larger inputs feel a bit bigger

### Mac
- Mac trackpads might not be something we support long term (but it's something I develop on lol). Mac has aggressive system scaling. In particular, small and medium swipes are very dampened. I've simply scaled in the input values up by 5 which makes it feel much closer to a normal mouse input