### PR TITLE
Allows pausing during taskpad pickup

### DIFF
--- a/Assets/Scripts/Interactables/Computer.cs
+++ b/Assets/Scripts/Interactables/Computer.cs
@@ -66,7 +66,7 @@ public class Computer : Interactable
         isInteractable = false;
 
         motor.ForcePlayerToPoint(lockPoint, true);
-        motor.ToggleMovementOverride();
+        motor.LockPlayer();
 
         if (!InputManager.Instance.GamepadIsCurrentInput())
             Cursor.lockState = CursorLockMode.None;
@@ -85,7 +85,7 @@ public class Computer : Interactable
 
     protected virtual void ReleasePlayer()
     {
-        motor.ToggleMovementOverride();
+        motor.LockPlayer();
         Cursor.lockState = CursorLockMode.Locked;
         look.ToggleLookLock();
         isInteractable = true;

--- a/Assets/Scripts/Interactables/DataReader.cs
+++ b/Assets/Scripts/Interactables/DataReader.cs
@@ -54,7 +54,7 @@ public class DataReader : Interactable
         {
             if(!InputManager.Instance.GamepadIsCurrentInput()) Cursor.lockState = CursorLockMode.None;
             InputManager.InputTypeChanged += InputChangedWhilstUIOpen;
-            player.GetComponent<PlayerMotor>().ToggleMovementOverride();
+            player.GetComponent<PlayerMotor>().LockPlayer();
             player.GetComponent<PlayerLook>().ToggleLookLock();
             UIManager.Instance.ToggleCrosshairVisibility();
 
@@ -111,7 +111,7 @@ public class DataReader : Interactable
 
         PDUI.SetActive(false);
         Cursor.lockState = CursorLockMode.Locked;
-        player.GetComponent<PlayerMotor>().ToggleMovementOverride();
+        player.GetComponent<PlayerMotor>().LockPlayer();
         player.GetComponent<PlayerLook>().ToggleLookLock();
         UIManager.Instance.ToggleCrosshairVisibility();
         InputManager.InputTypeChanged -= InputChangedWhilstUIOpen;

--- a/Assets/Scripts/Interactables/FocusPickup.cs
+++ b/Assets/Scripts/Interactables/FocusPickup.cs
@@ -45,7 +45,7 @@ public class FocusPickup : Interactable
 
         if(sfx != null) SoundManager.Instance.PlaySFXOneShot(sfx);
 
-        motor.ToggleMovementOverride();
+        motor.LockPlayer();
         look.ToggleLookLock();
 
         UIManager.Instance.ToggleCrosshairVisibility();
@@ -59,7 +59,7 @@ public class FocusPickup : Interactable
 
     public virtual void ReleasePlayer()
     {
-        motor.ToggleMovementOverride();
+        motor.LockPlayer();
         Cursor.lockState = CursorLockMode.Locked;
         look.ToggleLookLock();
         isInteractable = true;

--- a/Assets/Scripts/Interactables/Ladder.cs
+++ b/Assets/Scripts/Interactables/Ladder.cs
@@ -65,7 +65,7 @@ public class Ladder : Interactable
         }
 
         sfxTimer = 0f;
-        motor.ToggleMovementOverride();
+        motor.LockPlayer();
     }
 
 

--- a/Assets/Scripts/Player/PlayerMotor.cs
+++ b/Assets/Scripts/Player/PlayerMotor.cs
@@ -143,9 +143,10 @@ public class PlayerMotor : MonoBehaviour
         controller.enabled = true;
     }
 
-    public void ToggleMovementOverride()
+    public void LockPlayer(bool preventPause = true)
     {
         movementOverridden = !movementOverridden;
+        PauseManager.Instance.pauseIsBlocked = movementOverridden && preventPause;
     }
 
     private void FootstepSound()

--- a/Assets/Scripts/Tasks/TaskManager.cs
+++ b/Assets/Scripts/Tasks/TaskManager.cs
@@ -93,7 +93,7 @@ public class TaskManager : MonoBehaviour
     public void ObtainTaskpad()
     {
         taskPadObtained = true;
-        player.GetComponent<PlayerMotor>().ToggleMovementOverride();
+        player.GetComponent<PlayerMotor>().LockPlayer();
         taskPadObj.SetActive(true);
         ToggleTaskPad();
         RefreshTaskListUI();

--- a/Assets/Scripts/UI/PauseManager.cs
+++ b/Assets/Scripts/UI/PauseManager.cs
@@ -151,6 +151,7 @@ public class PauseManager : MonoBehaviour
         else
         {
             if (activePanel != null) activePanel.SettingsPanelDeselected();
+            SoundManager.Instance.UnpauseAllPausedSound();
             UIManager.Instance.ClearSelectedUIObject();
             UIManager.Instance.HideBackoutText();
             UIManager.Instance.HideConfirmText();

--- a/Assets/Scripts/UI/PauseManager.cs
+++ b/Assets/Scripts/UI/PauseManager.cs
@@ -6,6 +6,7 @@ using UnityEngine.UI;
 public class PauseManager : MonoBehaviour
 {
     public static PauseManager Instance { get; private set; }
+
     [SerializeField] private int mainMenuSceneIndex;
     [SerializeField] private Selectable initiallySelectedItem;
     [SerializeField] private List<SettingsPanel> settingsPanels;
@@ -15,13 +16,23 @@ public class PauseManager : MonoBehaviour
     [SerializeField] private Button cancelExitGame;
     [SerializeField] private GameObject confirmExitScreen;
 
+    public bool pauseIsBlocked = false;
+
     private const string MENUSELECT = "Select Menu Option";
     private const string BACKOUTMESSAGE = "To Resume Game";
     private const string CANCELEXIT = "Back to Settings";
 
     private void Awake()
     {
-        Instance = this;
+        if (Instance != null && Instance != this)
+        {
+            Destroy(this);
+        }
+        else
+        {
+            Instance = this;
+        }
+
         gameObject.SetActive(false);
     }
 
@@ -124,7 +135,7 @@ public class PauseManager : MonoBehaviour
 
     public void TogglePauseMenu()
     {
-        if (PlayerMotor.Instance.movementOverridden) return; // Pausing only possible outside of focus interactablesto avoid keybind clash
+        if (pauseIsBlocked) return; // Pausing only possible outside of focus interactablesto avoid keybind clash
 
         gameObject.SetActive(!gameObject.activeSelf);
         Time.timeScale = gameObject.activeSelf ? 0f : 1f;


### PR DESCRIPTION
Seperates the movement lock and pause lock into different attributes. By default locking the player into something toggles both, but initially movement is locked without pause being blocked