### PR TITLE
[Bug] Add extra logic for admin unlock servers

### DIFF
--- a/Assets/Scripts/Interactables/ServerDiscStorage.cs
+++ b/Assets/Scripts/Interactables/ServerDiscStorage.cs
@@ -28,7 +28,9 @@ public class ServerDiscStorage : Interactable
     public override bool CanInteract()
     {
         List<DataDrive> playerDrives = PlayerInventory.Instance.dataDrivesHeld;
-        return driveStored != null && (!playerDrives.Contains(driveStored) && driveInDock) || (playerDrives.Contains(driveStored) && !driveInDock);
+        ServerRack rack = GetComponentInParent<ServerRack>();
+        Debug.Log(rack.hasDisk);
+        return (driveStored != null && !playerDrives.Contains(driveStored) && driveInDock && rack.hasDisk) || (playerDrives.Contains(driveStored) && !driveInDock);
     }
 
     public override string GetPrompt()

--- a/Assets/Scripts/Interactables/ServerDiscStorage.cs
+++ b/Assets/Scripts/Interactables/ServerDiscStorage.cs
@@ -29,7 +29,6 @@ public class ServerDiscStorage : Interactable
     {
         List<DataDrive> playerDrives = PlayerInventory.Instance.dataDrivesHeld;
         ServerRack rack = GetComponentInParent<ServerRack>();
-        Debug.Log(rack.hasDisk);
         return (driveStored != null && !playerDrives.Contains(driveStored) && driveInDock && rack.hasDisk) || (playerDrives.Contains(driveStored) && !driveInDock);
     }
 

--- a/Assets/Scripts/Player/InputManager.cs
+++ b/Assets/Scripts/Player/InputManager.cs
@@ -1,4 +1,3 @@
-using Adobe.Substance.Connector;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.LowLevel;

--- a/Assets/Scripts/Player/PlayerInputManager.cs
+++ b/Assets/Scripts/Player/PlayerInputManager.cs
@@ -1,7 +1,4 @@
-using Adobe.Substance.Connector;
 using UnityEngine;
-using static InputManager;
-using UnityEngine.InputSystem;
 
 public class PlayerInputManager : MonoBehaviour
 {

--- a/Assets/Scripts/UI/Components/MenuSlider.cs
+++ b/Assets/Scripts/UI/Components/MenuSlider.cs
@@ -1,5 +1,4 @@
 using TMPro;
-using UnityEditor.Experimental.GraphView;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/Assets/Scripts/UI/SettingsPanel.cs
+++ b/Assets/Scripts/UI/SettingsPanel.cs
@@ -1,9 +1,6 @@
 using System.Collections.Generic;
-using TMPro;
-using UnityEditor.Experimental.GraphView;
 using UnityEngine;
 using UnityEngine.UI;
-using UnityEngine.Windows;
 
 public class SettingsPanel : MonoBehaviour
 {


### PR DESCRIPTION
### Bug
Admin unlock servers were interactable at the start of the game due to their ServerDiscStorage's not checking for anything related to the admin lock.

### Change
Upon getting admin access, we set a hasDisk property on the parent ServerRack to trigger light colour changes, I've added a check for the server disc storage to also only be interactable if this is set.

### Testing
1. All servers except the admin-only ones (30&31) AND the Sword Initiation one should be interactable before putting in the admin password in phase 1.
2. All servers except the admin-only ones (30&31) should be interactable before putting in the admin password during phase 2.
3. All servers should be accessible in phase 2 after the admin password is entered correctly.